### PR TITLE
remove unused Test::LoadAllModules from prereq list

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
@@ -556,7 +556,6 @@ sub configure {
       -phase => 'test',
       -type => 'requires',
       'Test::More' => '0.96',
-      'Test::LoadAllModules' => '0.021',
     } ],
   );
 


### PR DESCRIPTION
You're not using it in the pluginbundle, and it doesn't install right now because it uses Module::Install, which fails tests.

If you want a compile test in your dists, I recommend [Test::Compile]. And it's win32-friendly! :)