### PR TITLE
support for Alien::Base 0.005 features

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
@@ -368,7 +368,7 @@ for my $attr (@run_attributes) {
   );
 }
 
-my @alien_options = qw( repo name bins pattern_prefix pattern_suffix pattern_version pattern );
+my @alien_options = qw( repo name bins pattern_prefix pattern_suffix pattern_version pattern autoconf_with_pic isolate_dynamic );
 
 my @alien_attributes = map { 'alien_'.$_ } @alien_options;
 
@@ -377,7 +377,7 @@ for my $attr (@alien_attributes) {
     is      => 'ro',
     isa     => 'Str',
     lazy    => 1,
-    default => sub { $_[0]->payload->{$attr} || "" },
+    default => sub { defined $_[0]->payload->{$attr} ? $_[0]->payload->{$attr} : "" },
   );
 }
 
@@ -513,7 +513,7 @@ sub configure {
     my %alien_values;
     for (@alien_options) {
       my $func = 'alien_'.$_;
-      $alien_values{$_} = $self->$func if $self->$func;
+      $alien_values{$_} = $self->$func if defined $self->$func && $self->$func ne '';
     }
     $self->add_plugins([
       'Alien' => \%alien_values,


### PR DESCRIPTION
This adds support for `Alien::Base` 0.005 features.  This is contingent on this PR for `[Alien]`:

https://github.com/Getty/p5-dist-zilla-plugin-alien/pull/4

The rationale for this is `Alien::ffmpeg` will require `alien_autoconf_with_pic` be set to 0 for Alien::Base 0.005 and later.  I  will be sending a PR there as well shortly.

Thanks!
