### PR TITLE
Attempt to resolve version regexp for changelog generation.

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
@@ -545,7 +545,7 @@ sub configure {
       $self->add_plugins([
         'ChangelogFromGit' => {
           max_age => 99999,
-          tag_regexp => '^v(.+)$',
+          tag_regexp => '^v?(\d.+)$',
           file_name => 'Changes',
           wrap_column => 74,
           debug => 0,


### PR DESCRIPTION
This will permit tags that are versions but lack a 'v' prefix to be
considered version tags, and will thus make the changelog actually make
sense instead of being a continuous stream of garbage.