### PR TITLE
Alien: also support the version_check attribute

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/GETTY.pm
@@ -377,7 +377,7 @@ for my $attr (@run_attributes) {
   );
 }
 
-my @alien_options = qw( msys repo name bins pattern_prefix pattern_suffix pattern_version pattern autoconf_with_pic isolate_dynamic );
+my @alien_options = qw( msys repo name bins pattern_prefix pattern_suffix pattern_version pattern autoconf_with_pic isolate_dynamic version_check );
 
 my @alien_attributes = map { 'alien_'.$_ } @alien_options;
 


### PR DESCRIPTION
Will be needed for Alien::ffmpeg to detect that ffmpeg is installed by way of running "ffmpeg --version"